### PR TITLE
Migrate from bintray to maven central/github packages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,51 +1,40 @@
 name: Build
-
 on:
   [push]
-
 jobs:
   build:
     name: Build and Test
     runs-on: macos-latest
     if: "!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]')"
-    env:
-      BUILD_VERSION: SNAPSHOT
-    outputs:
-      artifact-version: ${{ steps.setversion.outputs.version }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v1
         with:
           java-version: 11
-          server-id: bintray-jcenter
-          server-username: BINTRAY_USERNAME
-          server-password: BINTRAY_API_KEY
-      - uses: actions/cache@v1
+      - uses: actions/cache@v2
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
       - name: Ensure to use tagged version
-        run: mvn versions:set --file ./pom.xml -DnewVersion=${GITHUB_REF##*/}
         if: startsWith(github.ref, 'refs/tags/')
-      - name: Export the project version to the job environment and fix it as an ouput of this job
-        id: setversion
-        run: |
-          v=$(mvn help:evaluate "-Dexpression=project.version" -q -DforceStdout)
-          echo "BUILD_VERSION=${v}" >> $GITHUB_ENV
-          echo "::set-output name=version::${v}"
         shell: bash
+        run: |
+          mvn versions:set --file ./pom.xml -DnewVersion=${GITHUB_REF##*/}
       - name: Build and Test
-        run: mvn -B install
-      - name: Upload .jars
-        uses: actions/upload-artifact@v2
+        id: buildAndTest
+        run: mvn -B clean install -Pdependency-check
+      - uses: actions/upload-artifact@v2
         with:
-          name: integrations-mac-${{ env.BUILD_VERSION }}
-          path: target/integrations-mac-*.jar
-      - name: Build and deploy to jcenter
+          name: artifacts
+          path: target/*.jar
+      - name: Create Release
+        uses: actions/create-release@v1
         if: startsWith(github.ref, 'refs/tags/')
-        run: mvn -B deploy -DskipTests
         env:
-          BINTRAY_USERNAME: cryptobot
-          BINTRAY_API_KEY: ${{ secrets.BINTRAY_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.CRYPTOBOT_RELEASE_TOKEN }} # release as "cryptobot"
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          prerelease: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
           mvn versions:set --file ./pom.xml -DnewVersion=${GITHUB_REF##*/}
       - name: Build and Test
         id: buildAndTest
-        run: mvn -B clean install -Pdependency-check
+        run: mvn -B clean install
       - uses: actions/upload-artifact@v2
         with:
           name: artifacts

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,37 @@
+
+name: "CodeQL"
+
+on:
+  push:
+    branches: [develop, main]
+  pull_request:
+    branches: [develop]
+  schedule:
+    - cron: '0 8 * * 0'
+
+jobs:
+  analyse:
+    name: Analyse
+    runs-on: macos-latest
+    if: "!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]')"
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 2
+    - uses: actions/setup-java@v1
+      with:
+        java-version: 11
+    - uses: actions/cache@v2
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ runner.os }}-maven-
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v1
+      with:
+        languages: java
+    - name: Build
+      run: mvn -B compile
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v1

--- a/.github/workflows/publish-central.yml
+++ b/.github/workflows/publish-central.yml
@@ -1,0 +1,37 @@
+name: Publish to Maven Central
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag'
+        required: true
+        default: '0.0.0'
+jobs:
+  publish:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: "refs/tags/${{ github.event.inputs.tag }}"
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 11
+          server-id: ossrh # Value of the distributionManagement/repository/id field of the pom.xml
+          server-username: MAVEN_USERNAME # env variable for username in deploy
+          server-password: MAVEN_PASSWORD # env variable for token in deploy
+          gpg-private-key: ${{ secrets.RELEASES_GPG_PRIVATE_KEY }} # Value of the GPG private key to import
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE # env variable for GPG private key passphrase
+      - uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - name: Enforce project version ${{ github.event.inputs.tag }}
+        run: mvn versions:set -B -DnewVersion=${{ github.event.inputs.tag }}
+      - name: Deploy
+        run: mvn deploy -B -DskipTests -Psign,deploy-central --no-transfer-progress
+        env:
+          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.RELEASES_GPG_PASSPHRASE }}

--- a/.github/workflows/publish-github.yml
+++ b/.github/workflows/publish-github.yml
@@ -35,6 +35,6 @@ jobs:
           SLACK_ICON_EMOJI: ':bot:'
           SLACK_CHANNEL: 'cryptomator-desktop'
           SLACK_TITLE: "Published ${{ github.event.repository.name }} ${{ github.event.release.tag_name }}"
-          SLACK_MESSAGE: "Ready to <https://github.com/${{ github.repository }}/actions?query=workflow%3A%22Publish+to+Maven+Central%22|deploy to Maven Central>."
+          SLACK_MESSAGE: "Ready to <https://github.com/${{ github.repository }}/actions/workflows/publish-central.yml|deploy to Maven Central>."
           SLACK_FOOTER:
           MSG_MINIMAL: true

--- a/.github/workflows/publish-github.yml
+++ b/.github/workflows/publish-github.yml
@@ -1,0 +1,40 @@
+name: Publish to GitHub Packages
+on:
+  release:
+    types: [published]
+jobs:
+  publish:
+    runs-on: macos-latest
+    if: startsWith(github.ref, 'refs/tags/') # only allow publishing tagged versions
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 11
+          gpg-private-key: ${{ secrets.RELEASES_GPG_PRIVATE_KEY }} # Value of the GPG private key to import
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE # env variable for GPG private key passphrase
+      - uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - name: Enforce project version ${{ github.event.release.tag_name }}
+        run: mvn versions:set -B -DnewVersion=${{ github.event.release.tag_name }}
+      - name: Deploy
+        run: mvn deploy -B -DskipTests -Psign,deploy-github --no-transfer-progress
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.RELEASES_GPG_PASSPHRASE }}
+      - name: Slack Notification
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_USERNAME: 'Cryptobot'
+          SLACK_ICON:
+          SLACK_ICON_EMOJI: ':bot:'
+          SLACK_CHANNEL: 'cryptomator-desktop'
+          SLACK_TITLE: "Published ${{ github.event.repository.name }} ${{ github.event.release.tag_name }}"
+          SLACK_MESSAGE: "Ready to <https://github.com/${{ github.repository }}/actions?query=workflow%3A%22Publish+to+Maven+Central%22|deploy to Maven Central>."
+          SLACK_FOOTER:
+          MSG_MINIMAL: true

--- a/pom.xml
+++ b/pom.xml
@@ -47,21 +47,6 @@
 		</license>
 	</licenses>
 
-	<repositories>
-		<repository>
-			<id>bintray</id>
-			<name>bintray</name>
-			<url>https://jcenter.bintray.com</url>
-		</repository>
-	</repositories>
-
-	<distributionManagement>
-		<repository>
-			<id>bintray-jcenter</id>
-			<url>https://api.bintray.com/maven/cryptomator/maven/integrations-mac/;publish=1</url>
-		</repository>
-	</distributionManagement>
-
 	<dependencies>
 		<dependency>
 			<groupId>org.cryptomator</groupId>
@@ -292,4 +277,70 @@
 			</plugin>
 		</plugins>
 	</build>
+
+	<profiles>
+		<profile>
+			<id>sign</id>
+			<build>
+				<plugins>
+					<plugin>
+						<artifactId>maven-gpg-plugin</artifactId>
+						<version>1.6</version>
+						<executions>
+							<execution>
+								<id>sign-artifacts</id>
+								<phase>verify</phase>
+								<goals>
+									<goal>sign</goal>
+								</goals>
+								<configuration>
+									<gpgArguments>
+										<arg>--pinentry-mode</arg>
+										<arg>loopback</arg>
+									</gpgArguments>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+
+		<profile>
+			<id>deploy-central</id>
+			<distributionManagement>
+				<repository>
+					<id>ossrh</id>
+					<name>Maven Central</name>
+					<url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+				</repository>
+			</distributionManagement>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.sonatype.plugins</groupId>
+						<artifactId>nexus-staging-maven-plugin</artifactId>
+						<version>1.6.8</version>
+						<extensions>true</extensions>
+						<configuration>
+							<serverId>ossrh</serverId>
+							<nexusUrl>https://oss.sonatype.org/</nexusUrl>
+							<autoReleaseAfterClose>true</autoReleaseAfterClose>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+
+		<profile>
+			<id>deploy-github</id>
+			<distributionManagement>
+				<repository>
+					<id>github</id>
+					<name>GitHub Packages</name>
+					<url>https://maven.pkg.github.com/cryptomator/integrations-api</url>
+				</repository>
+			</distributionManagement>
+		</profile>
+	</profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -338,7 +338,7 @@
 				<repository>
 					<id>github</id>
 					<name>GitHub Packages</name>
-					<url>https://maven.pkg.github.com/cryptomator/integrations-api</url>
+					<url>https://maven.pkg.github.com/cryptomator/integrations-mac</url>
 				</repository>
 			</distributionManagement>
 		</profile>


### PR DESCRIPTION
This PR migrates the repository CI system from bintray to github packages and maven central.

This is basically copy-paste from cryptomator/integrations-win repository. Unfortunately i don't know which env/repository variables are already set and which not. This should be checked and corrected before merging this PR.

As a side note: In the notification of the github packages workflow was removed in integrations-win (see https://github.com/cryptomator/integrations-win/commit/a5640dfccdc9ff6ad2274bad2829e79593062172). If this is intended. it should also be removed here.