### PR TITLE
Fixed maven builds for certain systems

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -174,7 +174,7 @@
 								<argument>-quiet</argument>
 								<argument>clean</argument>
 								<argument>archive</argument>
-								<argument>HEADER_SEARCH_PATHS="${java.home}/include/**"</argument>
+								<argument>JAVA_HOME="${java.home}"</argument>
 							</arguments>
 						</configuration>
 					</execution>

--- a/pom.xml
+++ b/pom.xml
@@ -174,7 +174,7 @@
 								<argument>-quiet</argument>
 								<argument>clean</argument>
 								<argument>archive</argument>
-								<argument>USER_HEADER_SEARCH_PATHS="${project.basedir}/src/main/headers/ ${java.home}/include/**"</argument>
+								<argument>HEADER_SEARCH_PATHS="${java.home}/include/**"</argument>
 							</arguments>
 						</configuration>
 					</execution>

--- a/src/main/native/Integrations.xcodeproj/project.pbxproj
+++ b/src/main/native/Integrations.xcodeproj/project.pbxproj
@@ -267,7 +267,9 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				EXECUTABLE_PREFIX = lib;
+				HEADER_SEARCH_PATHS = "/Library/Java/JavaVirtualMachines/adoptopenjdk-11.jdk/Contents/Home/include/**";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				USER_HEADER_SEARCH_PATHS = ../headers;
 			};
 			name = Debug;
 		};
@@ -277,7 +279,9 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				EXECUTABLE_PREFIX = lib;
+				HEADER_SEARCH_PATHS = "/Library/Java/JavaVirtualMachines/adoptopenjdk-11.jdk/Contents/Home/include/**";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				USER_HEADER_SEARCH_PATHS = ../headers;
 			};
 			name = Release;
 		};

--- a/src/main/native/Integrations.xcodeproj/project.pbxproj
+++ b/src/main/native/Integrations.xcodeproj/project.pbxproj
@@ -197,14 +197,13 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				HEADER_SEARCH_PATHS = (
-					"/Library/Java/JavaVirtualMachines/adoptopenjdk-11.jdk/Contents/Home/include/**",
-					../headers,
-				);
+				HEADER_SEARCH_PATHS = "$(JAVA_HOME)/include/**";
+				JAVA_HOME = "/Library/Java/JavaVirtualMachines/adoptopenjdk-11.jdk/Contents/Home";
 				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = macosx;
+				USER_HEADER_SEARCH_PATHS = ../headers;
 			};
 			name = Debug;
 		};
@@ -251,13 +250,12 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				HEADER_SEARCH_PATHS = (
-					"/Library/Java/JavaVirtualMachines/adoptopenjdk-11.jdk/Contents/Home/include/**",
-					../headers,
-				);
+				HEADER_SEARCH_PATHS = "$(JAVA_HOME)/include/**";
+				JAVA_HOME = "/Library/Java/JavaVirtualMachines/adoptopenjdk-11.jdk/Contents/Home";
 				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = macosx;
+				USER_HEADER_SEARCH_PATHS = ../headers;
 			};
 			name = Release;
 		};
@@ -267,9 +265,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				EXECUTABLE_PREFIX = lib;
-				HEADER_SEARCH_PATHS = "/Library/Java/JavaVirtualMachines/adoptopenjdk-11.jdk/Contents/Home/include/**";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				USER_HEADER_SEARCH_PATHS = ../headers;
 			};
 			name = Debug;
 		};
@@ -279,9 +275,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				EXECUTABLE_PREFIX = lib;
-				HEADER_SEARCH_PATHS = "/Library/Java/JavaVirtualMachines/adoptopenjdk-11.jdk/Contents/Home/include/**";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				USER_HEADER_SEARCH_PATHS = ../headers;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
**Maven builds could fail if a system setup differed from the default setup or if a different jdk was installed.
This was caused by a wrong argument in the maven build that didn't override the right settings.**

I also took the liberty to reorganize the headers (synonym with _header locations_) into system headers and user headers: The jdk provides system headers at `$JAVA_HOME/include/`, the local codebase provides user headers as `src/main/headers`. 
Previously both header locations were classified as system headers, but the maven script overrode them as user headers. This caused no issues on default systems (jdk 11 and default path), but failed on systems with different jdk versions or locations. Maven exec now overrides the jdk headers with the correct location and manages them as system headers. The Cryptomator user headers are of no concern to maven exec.

Further considerations:
- Adding a check for valid header locations (does the folder exist, etc.); currently both XCode and Maven failed rather strangely instead of telling the user that the header location doesn't exist. Also enforcing the correct jdk version should be considered.
- This bug only occurred when building from maven/XCode:
  - When using XCode the hard coded path to the jdk headers fails on non-default system, which is to be expected.
  - When using Maven the paths for the header locations from the XCode config (classified as system headers) took priority if the the build was started on non-default systems (maven supplied the differing settings as user headers; see above). It seems the user headers with the correct location were ignored.
  - When using the command that is generated by maven exec (see _Command 1_ below) the user headers took priority if the build was started on non-default systems and therefore finished correctly. It seems the system headers with the wrong location were ignored. Using the command in the terminal myself instead of maven was the only conceivable difference between these two operations. This leads me to the the conclusion that having invalid header locations somewhere in the mix leads to undetermined behavior. 
- XCode still uses a hard coded path for the jdk headers. I tried supplementing `$(JAVA_HOME)/include/**` in `project.pbxproj`, but had no positive results. Adding variables to the build settings is possible in general, but from my understanding importing environment variables requires further changes, that I'm unfamiliar with; see: https://github.com/cryptomator/integrations-mac/blob/441a5c126518f970a193c349e91bed02d9e56f5b/src/main/native/Integrations.xcodeproj/project.pbxproj#L271
- _Command 2_ is the equivalent to the updated maven exec settings. The argument in `[brackets]` is not included, but can be used to override the Cryptomator header location.
- For future reference: `xcodebuild [args...] -showBuildSettings` can be used to see all active settings for the given build

**Command 1 (to be executed from `<Project_Root>/src/main/native`):**
```
xcodebuild -project Integrations.xcodeproj -scheme Integrations -configuration Release -archivePath ../../../target/integrations.xcarchive -quiet clean archive USER_HEADER_SEARCH_PATHS="../headers $JAVA_HOME/include/**"
```

**Command 2 (to be executed from `<Project_Root>/src/main/native`):**
```
xcodebuild -project Integrations.xcodeproj -scheme Integrations -configuration Release -archivePath ../../../target/integrations.xcarchive -quiet clean archive HEADER_SEARCH_PATHS="$JAVA_HOME/include/**" [USER_HEADER_SEARCH_PATHS="../headers"]
```