### PR TITLE
Make keychain service name configurable

### DIFF
--- a/src/main/headers/org_cryptomator_macos_keychain_MacKeychain_Native.h
+++ b/src/main/headers/org_cryptomator_macos_keychain_MacKeychain_Native.h
@@ -10,26 +10,26 @@ extern "C" {
 /*
  * Class:     org_cryptomator_macos_keychain_MacKeychain_Native
  * Method:    storePassword
- * Signature: ([B[B)I
+ * Signature: ([B[B[B)I
  */
 JNIEXPORT jint JNICALL Java_org_cryptomator_macos_keychain_MacKeychain_00024Native_storePassword
-  (JNIEnv *, jobject, jbyteArray, jbyteArray);
+  (JNIEnv *, jobject, jbyteArray, jbyteArray, jbyteArray);
 
 /*
  * Class:     org_cryptomator_macos_keychain_MacKeychain_Native
  * Method:    loadPassword
- * Signature: ([B)[B
+ * Signature: ([B[B)[B
  */
 JNIEXPORT jbyteArray JNICALL Java_org_cryptomator_macos_keychain_MacKeychain_00024Native_loadPassword
-  (JNIEnv *, jobject, jbyteArray);
+  (JNIEnv *, jobject, jbyteArray, jbyteArray);
 
 /*
  * Class:     org_cryptomator_macos_keychain_MacKeychain_Native
  * Method:    deletePassword
- * Signature: ([B)I
+ * Signature: ([B[B)I
  */
 JNIEXPORT jint JNICALL Java_org_cryptomator_macos_keychain_MacKeychain_00024Native_deletePassword
-  (JNIEnv *, jobject, jbyteArray);
+  (JNIEnv *, jobject, jbyteArray, jbyteArray);
 
 #ifdef __cplusplus
 }

--- a/src/main/java/org/cryptomator/macos/keychain/MacKeychain.java
+++ b/src/main/java/org/cryptomator/macos/keychain/MacKeychain.java
@@ -17,14 +17,16 @@ class MacKeychain {
 	/**
 	 * Associates the specified password with the specified key in the system keychain.
 	 *
+	 * @param serviceName Service name
 	 * @param account Unique account identifier
 	 * @param password Passphrase to store
+	 * @see <a href="https://developer.apple.com/documentation/security/1398366-seckeychainaddgenericpassword">SecKeychainAddGenericPassword</a>
 	 */
-	public void storePassword(String account, CharSequence password) throws KeychainAccessException {
+	public void storePassword(String serviceName, String account, CharSequence password) throws KeychainAccessException {
 		ByteBuffer pwBuf = UTF_8.encode(CharBuffer.wrap(password));
 		byte[] pwBytes = new byte[pwBuf.remaining()];
 		pwBuf.get(pwBytes);
-		int errorCode = Native.INSTANCE.storePassword(account.getBytes(UTF_8), pwBytes);
+		int errorCode = Native.INSTANCE.storePassword(serviceName.getBytes(UTF_8), account.getBytes(UTF_8), pwBytes);
 		Arrays.fill(pwBytes, (byte) 0x00);
 		Arrays.fill(pwBuf.array(), (byte) 0x00);
 		if (errorCode != OSSTATUS_SUCCESS) {
@@ -35,11 +37,13 @@ class MacKeychain {
 	/**
 	 * Loads the password associated with the specified key from the system keychain.
 	 *
+	 * @param serviceName Service name
 	 * @param account Unique account identifier
 	 * @return password or <code>null</code> if no such keychain entry could be loaded from the keychain.
+	 * @see <a href="https://developer.apple.com/documentation/security/1397301-seckeychainfindgenericpassword">SecKeychainFindGenericPassword</a>
 	 */
-	public char[] loadPassword(String account) {
-		byte[] pwBytes = Native.INSTANCE.loadPassword(account.getBytes(UTF_8));
+	public char[] loadPassword(String serviceName, String account) {
+		byte[] pwBytes = Native.INSTANCE.loadPassword(serviceName.getBytes(UTF_8), account.getBytes(UTF_8));
 		if (pwBytes == null) {
 			return null;
 		} else {
@@ -55,11 +59,14 @@ class MacKeychain {
 	/**
 	 * Deletes the password associated with the specified key from the system keychain.
 	 *
+	 * @param serviceName Service name
 	 * @param account Unique account identifier
 	 * @return <code>true</code> if the passwords has been deleted, <code>false</code> if no entry for the given key exists.
+	 * @see <a href="https://developer.apple.com/documentation/security/1395547-secitemdelete">SecKeychainItemDelete</a>
+
 	 */
-	public boolean deletePassword(String account) throws KeychainAccessException {
-		int errorCode = Native.INSTANCE.deletePassword(account.getBytes(UTF_8));
+	public boolean deletePassword(String serviceName, String account) throws KeychainAccessException {
+		int errorCode = Native.INSTANCE.deletePassword(serviceName.getBytes(UTF_8), account.getBytes(UTF_8));
 		if (errorCode == OSSTATUS_SUCCESS) {
 			return true;
 		} else if (errorCode == OSSTATUS_NOT_FOUND) {
@@ -77,11 +84,11 @@ class MacKeychain {
 			NativeLibLoader.loadLib();
 		}
 
-		public native int storePassword(byte[] account, byte[] value);
+		public native int storePassword(byte[] service, byte[] account, byte[] value);
 
-		public native byte[] loadPassword(byte[] account);
+		public native byte[] loadPassword(byte[] service, byte[] account);
 
-		public native int deletePassword(byte[] account);
+		public native int deletePassword(byte[] service, byte[] account);
 	}
 
 }

--- a/src/main/java/org/cryptomator/macos/keychain/MacSystemKeychainAccess.java
+++ b/src/main/java/org/cryptomator/macos/keychain/MacSystemKeychainAccess.java
@@ -6,9 +6,17 @@ import org.cryptomator.integrations.keychain.KeychainAccessException;
 import org.cryptomator.integrations.keychain.KeychainAccessProvider;
 import org.cryptomator.macos.common.Localization;
 
+/**
+ * Stores passwords in the macOS system keychain.
+ * <p>
+ * Items are stored in the default keychain with the service name <code>Cryptomator</code>, unless configured otherwise
+ * using the system property <code>cryptomator.integrationsMac.keychainServiceName</code>.
+ */
 @Priority(1000)
 @OperatingSystem(OperatingSystem.Value.MAC)
 public class MacSystemKeychainAccess implements KeychainAccessProvider {
+
+	private static final String SERVICE_NAME = System.getProperty("cryptomator.integrationsMac.keychainServiceName", "Cryptomator");
 
 	private final MacKeychain keychain;
 
@@ -28,12 +36,12 @@ public class MacSystemKeychainAccess implements KeychainAccessProvider {
 
 	@Override
 	public void storePassphrase(String key, String displayName, CharSequence passphrase) throws KeychainAccessException {
-		keychain.storePassword(key, passphrase);
+		keychain.storePassword(SERVICE_NAME, key, passphrase);
 	}
 
 	@Override
 	public char[] loadPassphrase(String key) {
-		return keychain.loadPassword(key);
+		return keychain.loadPassword(SERVICE_NAME, key);
 	}
 
 	@Override
@@ -48,13 +56,13 @@ public class MacSystemKeychainAccess implements KeychainAccessProvider {
 
 	@Override
 	public void deletePassphrase(String key) throws KeychainAccessException {
-		keychain.deletePassword(key);
+		keychain.deletePassword(SERVICE_NAME, key);
 	}
 
 	@Override
 	public void changePassphrase(String key, String displayName, CharSequence passphrase) throws KeychainAccessException {
-		if (keychain.deletePassword(key)) {
-			keychain.storePassword(key, passphrase);
+		if (keychain.deletePassword(SERVICE_NAME, key)) {
+			keychain.storePassword(SERVICE_NAME, key, passphrase);
 		}
 	}
 

--- a/src/main/native/org_cryptomator_macos_keychain_MacKeychain_Native.m
+++ b/src/main/native/org_cryptomator_macos_keychain_MacKeychain_Native.m
@@ -11,7 +11,7 @@
 
 JNIEXPORT jint JNICALL Java_org_cryptomator_macos_keychain_MacKeychain_00024Native_storePassword(JNIEnv *env, jobject thisObj, jbyteArray service, jbyteArray key, jbyteArray password) {
 	const int serviceLen = (*env)->GetArrayLength(env, service);
-    jbyte *serviceStr = (*env)->GetByteArrayElements(env, service, NULL);
+	jbyte *serviceStr = (*env)->GetByteArrayElements(env, service, NULL);
 	const int keyLen = (*env)->GetArrayLength(env, key);
 	jbyte *keyStr = (*env)->GetByteArrayElements(env, key, NULL);
 	const int pwLen = (*env)->GetArrayLength(env, password);
@@ -41,8 +41,8 @@ JNIEXPORT jint JNICALL Java_org_cryptomator_macos_keychain_MacKeychain_00024Nati
 		// add new:
 		status = SecKeychainAddGenericPassword(
 		    NULL,                // default keychain
-            serviceLen,          // length of service name
-            (char *)serviceStr,  // service name
+		    serviceLen,          // length of service name
+		    (char *)serviceStr,  // service name
 		    keyLen,              // length of account name
 		    (char *)keyStr,      // account name
 		    pwLen,               // length of password
@@ -61,7 +61,7 @@ JNIEXPORT jint JNICALL Java_org_cryptomator_macos_keychain_MacKeychain_00024Nati
 
 JNIEXPORT jbyteArray JNICALL Java_org_cryptomator_macos_keychain_MacKeychain_00024Native_loadPassword(JNIEnv *env, jobject thisObj, jbyteArray service, jbyteArray key) {
 	const int serviceLen = (*env)->GetArrayLength(env, service);
-    jbyte *serviceStr = (*env)->GetByteArrayElements(env, service, NULL);
+	jbyte *serviceStr = (*env)->GetByteArrayElements(env, service, NULL);
 	const int keyLen = (*env)->GetArrayLength(env, key);
 	jbyte *keyStr = (*env)->GetByteArrayElements(env, key, NULL);
 	void *pwStr = NULL;
@@ -94,7 +94,7 @@ JNIEXPORT jbyteArray JNICALL Java_org_cryptomator_macos_keychain_MacKeychain_000
 
 JNIEXPORT jint JNICALL Java_org_cryptomator_macos_keychain_MacKeychain_00024Native_deletePassword(JNIEnv *env, jobject thisObj, jbyteArray service, jbyteArray key) {
 	const int serviceLen = (*env)->GetArrayLength(env, service);
-    jbyte *serviceStr = (*env)->GetByteArrayElements(env, service, NULL);
+	jbyte *serviceStr = (*env)->GetByteArrayElements(env, service, NULL);
 	const int keyLen = (*env)->GetArrayLength(env, key);
 	jbyte *keyStr = (*env)->GetByteArrayElements(env, key, NULL);
 	SecKeychainItemRef itemRef = NULL;

--- a/src/main/native/org_cryptomator_macos_keychain_MacKeychain_Native.m
+++ b/src/main/native/org_cryptomator_macos_keychain_MacKeychain_Native.m
@@ -9,9 +9,9 @@
 #import "org_cryptomator_macos_keychain_MacKeychain_Native.h"
 #import <Security/Security.h>
 
-static const char CRYPTOMATOR[] = "Cryptomator";
-
-JNIEXPORT jint JNICALL Java_org_cryptomator_macos_keychain_MacKeychain_00024Native_storePassword(JNIEnv *env, jobject thisObj, jbyteArray key, jbyteArray password) {
+JNIEXPORT jint JNICALL Java_org_cryptomator_macos_keychain_MacKeychain_00024Native_storePassword(JNIEnv *env, jobject thisObj, jbyteArray service, jbyteArray key, jbyteArray password) {
+	const int serviceLen = (*env)->GetArrayLength(env, service);
+    jbyte *serviceStr = (*env)->GetByteArrayElements(env, service, NULL);
 	const int keyLen = (*env)->GetArrayLength(env, key);
 	jbyte *keyStr = (*env)->GetByteArrayElements(env, key, NULL);
 	const int pwLen = (*env)->GetArrayLength(env, password);
@@ -21,8 +21,8 @@ JNIEXPORT jint JNICALL Java_org_cryptomator_macos_keychain_MacKeychain_00024Nati
 	SecKeychainItemRef itemRef = NULL;
 	OSStatus status = SecKeychainFindGenericPassword(
 	    NULL,                // default keychain
-	    sizeof(CRYPTOMATOR), // length of service name
-	    CRYPTOMATOR,         // service name
+	    serviceLen,          // length of service name
+	    (char *)serviceStr,  // service name
 	    keyLen,              // length of account name
 	    (char *)keyStr,      // account name
 	    NULL,                // length of password
@@ -41,8 +41,8 @@ JNIEXPORT jint JNICALL Java_org_cryptomator_macos_keychain_MacKeychain_00024Nati
 		// add new:
 		status = SecKeychainAddGenericPassword(
 		    NULL,                // default keychain
-		    sizeof(CRYPTOMATOR), // length of service name
-		    CRYPTOMATOR,         // service name
+            serviceLen,          // length of service name
+            (char *)serviceStr,  // service name
 		    keyLen,              // length of account name
 		    (char *)keyStr,      // account name
 		    pwLen,               // length of password
@@ -59,15 +59,17 @@ JNIEXPORT jint JNICALL Java_org_cryptomator_macos_keychain_MacKeychain_00024Nati
 	return status;
 }
 
-JNIEXPORT jbyteArray JNICALL Java_org_cryptomator_macos_keychain_MacKeychain_00024Native_loadPassword(JNIEnv *env, jobject thisObj, jbyteArray key) {
+JNIEXPORT jbyteArray JNICALL Java_org_cryptomator_macos_keychain_MacKeychain_00024Native_loadPassword(JNIEnv *env, jobject thisObj, jbyteArray service, jbyteArray key) {
+	const int serviceLen = (*env)->GetArrayLength(env, service);
+    jbyte *serviceStr = (*env)->GetByteArrayElements(env, service, NULL);
 	const int keyLen = (*env)->GetArrayLength(env, key);
 	jbyte *keyStr = (*env)->GetByteArrayElements(env, key, NULL);
 	void *pwStr = NULL;
 	UInt32 pwLen;
 	OSStatus status = SecKeychainFindGenericPassword(
 	    NULL,                // default keychain
-	    sizeof(CRYPTOMATOR), // length of service name
-	    CRYPTOMATOR,         // service name
+	    serviceLen,          // length of service name
+	    (char *)serviceStr,  // service name
 	    keyLen,              // length of account name
 	    (char *)keyStr,      // account name
 	    &pwLen,              // length of password
@@ -90,14 +92,16 @@ JNIEXPORT jbyteArray JNICALL Java_org_cryptomator_macos_keychain_MacKeychain_000
 	return result;
 }
 
-JNIEXPORT jint JNICALL Java_org_cryptomator_macos_keychain_MacKeychain_00024Native_deletePassword(JNIEnv *env, jobject thisObj, jbyteArray key) {
+JNIEXPORT jint JNICALL Java_org_cryptomator_macos_keychain_MacKeychain_00024Native_deletePassword(JNIEnv *env, jobject thisObj, jbyteArray service, jbyteArray key) {
+	const int serviceLen = (*env)->GetArrayLength(env, service);
+    jbyte *serviceStr = (*env)->GetByteArrayElements(env, service, NULL);
 	const int keyLen = (*env)->GetArrayLength(env, key);
 	jbyte *keyStr = (*env)->GetByteArrayElements(env, key, NULL);
 	SecKeychainItemRef itemRef = NULL;
 	OSStatus status = SecKeychainFindGenericPassword(
 	    NULL,                // default keychain
-	    sizeof(CRYPTOMATOR), // length of service name
-	    CRYPTOMATOR,         // service name
+	    serviceLen,          // length of service name
+	    (char *)serviceStr,  // service name
 	    keyLen,              // length of account name
 	    (char *)keyStr,      // account name
 	    NULL,                // length of password

--- a/src/test/java/org/cryptomator/macos/keychain/MacSystemKeychainAccessTest.java
+++ b/src/test/java/org/cryptomator/macos/keychain/MacSystemKeychainAccessTest.java
@@ -31,14 +31,14 @@ public class MacSystemKeychainAccessTest {
 	public void testStoreSuccess() throws KeychainAccessException {
 		keychainAccess.storePassphrase("key", "pass");
 
-		Mockito.verify(keychain).storePassword("key", "pass");
+		Mockito.verify(keychain).storePassword("Cryptomator", "key", "pass");
 	}
 
 	@Test
 	@DisplayName("storePassphrase() fails")
 	public void testStoreError() throws KeychainAccessException {
 		KeychainAccessException e = new KeychainAccessException("fail.");
-		Mockito.doThrow(e).when(keychain).storePassword(Mockito.any(), Mockito.any());
+		Mockito.doThrow(e).when(keychain).storePassword(Mockito.eq("Cryptomator"), Mockito.any(), Mockito.any());
 
 		KeychainAccessException thrown = Assertions.assertThrows(KeychainAccessException.class, () -> {
 			keychainAccess.storePassphrase("key", "pass");
@@ -49,7 +49,7 @@ public class MacSystemKeychainAccessTest {
 	@Test
 	@DisplayName("loadPassphrase() succeeds")
 	public void testLoadSuccess() {
-		Mockito.when(keychain.loadPassword("key")).thenReturn("pass".toCharArray());
+		Mockito.when(keychain.loadPassword("Cryptomator", "key")).thenReturn("pass".toCharArray());
 
 		char[] result = keychainAccess.loadPassphrase("key");
 
@@ -59,7 +59,7 @@ public class MacSystemKeychainAccessTest {
 	@Test
 	@DisplayName("loadPassphrase() doesn't find pw")
 	public void testLoadNotFound() {
-		Mockito.when(keychain.loadPassword("key")).thenReturn(null);
+		Mockito.when(keychain.loadPassword("Cryptomator", "key")).thenReturn(null);
 
 		char[] result = keychainAccess.loadPassphrase("key");
 
@@ -71,14 +71,14 @@ public class MacSystemKeychainAccessTest {
 	public void testDeleteSuccess() throws KeychainAccessException {
 		keychainAccess.deletePassphrase("key");
 
-		Mockito.verify(keychain).deletePassword("key");
+		Mockito.verify(keychain).deletePassword("Cryptomator", "key");
 	}
 
 	@Test
 	@DisplayName("deletePassphrase() fails")
 	public void testDeleteError() throws KeychainAccessException {
 		KeychainAccessException e = new KeychainAccessException("fail.");
-		Mockito.doThrow(e).when(keychain).deletePassword(Mockito.any());
+		Mockito.doThrow(e).when(keychain).deletePassword(Mockito.eq("Cryptomator"), Mockito.any());
 
 		KeychainAccessException thrown = Assertions.assertThrows(KeychainAccessException.class, () -> {
 			keychainAccess.deletePassphrase("key");
@@ -89,28 +89,28 @@ public class MacSystemKeychainAccessTest {
 	@Test
 	@DisplayName("changePassphrase() succeeds")
 	public void testChangeSuccess() throws KeychainAccessException {
-		Mockito.when(keychain.deletePassword("key")).thenReturn(true);
+		Mockito.when(keychain.deletePassword("Cryptomator", "key")).thenReturn(true);
 
 		keychainAccess.changePassphrase("key", "newpass");
 
-		Mockito.verify(keychain).storePassword("key", "newpass");
+		Mockito.verify(keychain).storePassword("Cryptomator", "key", "newpass");
 	}
 
 	@Test
 	@DisplayName("changePassphrase() doesn't find pw")
 	public void testChangeNotFound() throws KeychainAccessException {
-		Mockito.when(keychain.deletePassword("key")).thenReturn(false);
+		Mockito.when(keychain.deletePassword("Cryptomator", "key")).thenReturn(false);
 
 		keychainAccess.changePassphrase("key", "newpass");
 
-		Mockito.verify(keychain, Mockito.never()).storePassword("key", "newpass");
+		Mockito.verify(keychain, Mockito.never()).storePassword("Cryptomator", "key", "newpass");
 	}
 
 	@Test
 	@DisplayName("changePassphrase() fails")
 	public void testChangeError() throws KeychainAccessException {
 		KeychainAccessException e = new KeychainAccessException("fail.");
-		Mockito.doThrow(e).when(keychain).deletePassword(Mockito.any());
+		Mockito.doThrow(e).when(keychain).deletePassword(Mockito.eq("Cryptomator"), Mockito.any());
 
 		KeychainAccessException thrown = Assertions.assertThrows(KeychainAccessException.class, () -> {
 			keychainAccess.changePassphrase("key", "newpass");


### PR DESCRIPTION
Replace hard-coded string "Cryptomator" with system property `cryptomator.integrationsMac.keychainServiceName`, which still defaults to "Cryptomator" but allows using alternative names in white labels.