### PR TITLE
implicitly migrate broken entries during `loadPassword(...)`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -284,6 +284,7 @@
 							<cveValidForHours>24</cveValidForHours>
 							<failBuildOnCVSS>0</failBuildOnCVSS>
 							<skipTestScope>true</skipTestScope>
+							<cveStartYear>2019</cveStartYear>
 							<detail>true</detail>
 							<suppressionFile>suppression.xml</suppressionFile>
 						</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
 		<mockito.version>4.4.0</mockito.version>
 
 		<!-- build plugin dependencies -->
-		<dependency-check.version>7.0.0</dependency-check.version>
+		<dependency-check.version>7.1.1</dependency-check.version>
 		<nexus-staging.version>1.6.8</nexus-staging.version>
 	</properties>
 


### PR DESCRIPTION
This fixes #13 by correcting old (broken) keychain entries during invocations of `char[] loadPassword(String serviceName, String account)`.

This fix is only applicable if `"Cryptomator".equals(serviceName)`, as any other service names should not be affected by this bug.

If a keychain entry has not been found with the new (correct) name but only with the old (incorrect) name, the password is stored using the new name and the old entry is deleted.