### PR TITLE
Feature: Implement Provider for ReveaPathService

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 		<project.jdk.version>17</project.jdk.version>
 
 		<!-- runtime dependencies -->
-		<api.version>1.1.0</api.version>
+		<api.version>1.2.0-beta4</api.version>
 		<slf4j.version>1.7.36</slf4j.version>
 
 		<!-- test dependencies -->

--- a/src/main/java/org/cryptomator/macos/revealpath/OpenCmdRevealPathService.java
+++ b/src/main/java/org/cryptomator/macos/revealpath/OpenCmdRevealPathService.java
@@ -20,7 +20,7 @@ public class OpenCmdRevealPathService implements RevealPathService {
 	public void reveal(Path p) throws RevealFailedException {
 		try {
 			var attrs = Files.readAttributes(p, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
-			ProcessBuilder pb = new ProcessBuilder().command("open", attrs.isDirectory()?"":"-R" ,"\"" + p.toString()+"\"");
+			ProcessBuilder pb = new ProcessBuilder().command("open", attrs.isDirectory() ? "" : "-R", p.toString());
 			var process = pb.start();
 			if (process.waitFor(5000, TimeUnit.MILLISECONDS)) {
 				int exitValue = process.exitValue();
@@ -40,4 +40,5 @@ public class OpenCmdRevealPathService implements RevealPathService {
 	public boolean isSupported() {
 		return true;
 	}
+
 }

--- a/src/main/java/org/cryptomator/macos/revealpath/OpenCmdRevealPathService.java
+++ b/src/main/java/org/cryptomator/macos/revealpath/OpenCmdRevealPathService.java
@@ -1,0 +1,43 @@
+package org.cryptomator.macos.revealpath;
+
+import org.cryptomator.integrations.common.OperatingSystem;
+import org.cryptomator.integrations.common.Priority;
+import org.cryptomator.integrations.revealpath.RevealFailedException;
+import org.cryptomator.integrations.revealpath.RevealPathService;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.concurrent.TimeUnit;
+
+@Priority(100)
+@OperatingSystem(OperatingSystem.Value.MAC)
+public class OpenCmdRevealPathService implements RevealPathService {
+
+	@Override
+	public void reveal(Path p) throws RevealFailedException {
+		try {
+			var attrs = Files.readAttributes(p, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
+			ProcessBuilder pb = new ProcessBuilder().command("open", attrs.isDirectory()?"":"-R" ,"\"" + p.toString()+"\"");
+			var process = pb.start();
+			if (process.waitFor(5000, TimeUnit.MILLISECONDS)) {
+				int exitValue = process.exitValue();
+				if (process.exitValue() != 0) {
+					throw new RevealFailedException("open command exited with value " + exitValue);
+				}
+			}
+		} catch (IOException e) {
+			throw new RevealFailedException(e);
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			throw new RevealFailedException(e);
+		}
+	}
+
+	@Override
+	public boolean isSupported() {
+		return true;
+	}
+}

--- a/src/test/java/org/cryptomator/macos/revealpath/OpenCmdRevealPathServiceTest.java
+++ b/src/test/java/org/cryptomator/macos/revealpath/OpenCmdRevealPathServiceTest.java
@@ -1,0 +1,28 @@
+package org.cryptomator.macos.revealpath;
+
+import org.cryptomator.integrations.revealpath.RevealFailedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+
+@Disabled
+public class OpenCmdRevealPathServiceTest {
+
+	@TempDir
+	Path tmpDir;
+
+	OpenCmdRevealPathService inTest = new OpenCmdRevealPathService();
+
+	@Test
+	public void testRevealSuccess() {
+		Assertions.assertDoesNotThrow(() -> inTest.reveal(tmpDir));
+	}
+
+	@Test
+	public void testRevealFail() {
+		Assertions.assertThrows(RevealFailedException.class, () -> inTest.reveal(tmpDir.resolve("foobar")));
+	}
+}

--- a/src/test/java/org/cryptomator/macos/revealpath/OpenCmdRevealPathServiceTest.java
+++ b/src/test/java/org/cryptomator/macos/revealpath/OpenCmdRevealPathServiceTest.java
@@ -6,6 +6,8 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 
 @Disabled
@@ -17,12 +19,20 @@ public class OpenCmdRevealPathServiceTest {
 	OpenCmdRevealPathService inTest = new OpenCmdRevealPathService();
 
 	@Test
-	public void testRevealSuccess() {
+	public void testRevealDirSuccess() {
 		Assertions.assertDoesNotThrow(() -> inTest.reveal(tmpDir));
+	}
+
+	@Test
+	public void testRevealFileSuccess() throws IOException {
+		var path = tmpDir.resolve("foobar.text");
+		Files.createFile(path);
+		Assertions.assertDoesNotThrow(() -> inTest.reveal(path));
 	}
 
 	@Test
 	public void testRevealFail() {
 		Assertions.assertThrows(RevealFailedException.class, () -> inTest.reveal(tmpDir.resolve("foobar")));
 	}
+
 }


### PR DESCRIPTION
This PR adds a provider for the [RevealPathService](https://github.com/cryptomator/integrations-api/releases/tag/1.2.0-beta4).

The Provider uses the macOS `open` command to show files in directories or open directories.