### PR TITLE
Replace the deprecated SecKeychain with SecItem

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,8 +38,8 @@
 		<mockito.version>5.11.0</mockito.version>
 
 		<!-- build plugin dependencies -->
-		<dependency-check.version>9.1.0</dependency-check.version>
-		<nexus-staging.version>1.6.13</nexus-staging.version>
+		<dependency-check.version>9.2.0</dependency-check.version>
+		<nexus-staging.version>1.6.14</nexus-staging.version>
 	</properties>
 
 	<licenses>
@@ -116,7 +116,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-enforcer-plugin</artifactId>
-				<version>3.4.1</version>
+				<version>3.5.0</version>
 				<executions>
 					<execution>
 						<id>check-preconditions</id>
@@ -145,7 +145,7 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>exec-maven-plugin</artifactId>
-				<version>3.2.0</version>
+				<version>3.3.0</version>
 				<executions>
 					<execution>
 						<goals>
@@ -203,7 +203,7 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-source-plugin</artifactId>
-				<version>3.3.0</version>
+				<version>3.3.1</version>
 				<executions>
 					<execution>
 						<id>attach-sources</id>
@@ -215,7 +215,7 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>3.6.3</version>
+				<version>3.7.0</version>
 				<executions>
 					<execution>
 						<id>attach-javadocs</id>
@@ -307,7 +307,7 @@
 				<plugins>
 					<plugin>
 						<artifactId>maven-gpg-plugin</artifactId>
-						<version>3.2.2</version>
+						<version>3.2.4</version>
 						<executions>
 							<execution>
 								<id>sign-artifacts</id>
@@ -368,7 +368,7 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-deploy-plugin</artifactId>
-						<version>3.1.1</version>
+						<version>3.1.2</version>
 					</plugin>
 				</plugins>
 			</build>

--- a/src/main/native/org_cryptomator_macos_keychain_MacKeychain_Native.m
+++ b/src/main/native/org_cryptomator_macos_keychain_MacKeychain_Native.m
@@ -17,112 +17,112 @@ JNIEXPORT jint JNICALL Java_org_cryptomator_macos_keychain_MacKeychain_00024Nati
 	jsize length = (*env)->GetArrayLength(env, password);
 
 	// find existing:
-    NSDictionary *searchAttributes = @{
-        (__bridge id)kSecClass: (__bridge id)kSecClassGenericPassword,
-        (__bridge id)kSecAttrService: [NSString stringWithCString:(char *)serviceStr encoding:NSUTF8StringEncoding],
-        (__bridge id)kSecAttrAccount: [NSString stringWithCString:(char *)keyStr encoding:NSUTF8StringEncoding],
-        (__bridge id)kSecReturnAttributes: @YES,
-        (__bridge id)kSecReturnData: @YES,
-        (__bridge id)kSecMatchLimit: (__bridge id)kSecMatchLimitOne
-    };
-        
-    CFDictionaryRef result = NULL;
-    OSStatus status = SecItemCopyMatching((__bridge CFDictionaryRef)searchAttributes, (CFTypeRef *)&result);
+	NSDictionary *searchAttributes = @{
+		(__bridge id)kSecClass: (__bridge id)kSecClassGenericPassword,
+		(__bridge id)kSecAttrService: [NSString stringWithCString:(char *)serviceStr encoding:NSUTF8StringEncoding],
+		(__bridge id)kSecAttrAccount: [NSString stringWithCString:(char *)keyStr encoding:NSUTF8StringEncoding],
+		(__bridge id)kSecReturnAttributes: @YES,
+		(__bridge id)kSecReturnData: @YES,
+		(__bridge id)kSecMatchLimit: (__bridge id)kSecMatchLimitOne
+	};
 
-    if (status == errSecSuccess && result != NULL) {
-        // update existing:
-        NSDictionary *changeAttributes = @{
-            (__bridge id)kSecValueData: [NSData dataWithBytes:pwStr length:length]
-        };
+	CFDictionaryRef result = NULL;
+	OSStatus status = SecItemCopyMatching((__bridge CFDictionaryRef)searchAttributes, (CFTypeRef *)&result);
 
-        status = SecItemUpdate((__bridge CFDictionaryRef)searchAttributes, (__bridge CFDictionaryRef)changeAttributes);
+	if (status == errSecSuccess && result != NULL) {
+		// update existing:
+		NSDictionary *changeAttributes = @{
+			(__bridge id)kSecValueData: [NSData dataWithBytes:pwStr length:length]
+		};
 
-        } else if (status == errSecItemNotFound) {
-            // add new:
-            NSDictionary *keychainAttributes = @{
-                (__bridge id)kSecClass: (__bridge id)kSecClassGenericPassword,
-                (__bridge id)kSecAttrService: [NSString stringWithCString:(char *)serviceStr encoding:NSUTF8StringEncoding],
-                (__bridge id)kSecAttrAccount: [NSString stringWithCString:(char *)keyStr encoding:NSUTF8StringEncoding],
-                (__bridge id)kSecValueData: [NSData dataWithBytes:pwStr length:length]
-            };
+		status = SecItemUpdate((__bridge CFDictionaryRef)searchAttributes, (__bridge CFDictionaryRef)changeAttributes);
 
-            status = SecItemAdd((__bridge CFDictionaryRef)keychainAttributes, NULL);
+	} else if (status == errSecItemNotFound) {
+		// add new:
+		NSDictionary *keychainAttributes = @{
+			(__bridge id)kSecClass: (__bridge id)kSecClassGenericPassword,
+			(__bridge id)kSecAttrService: [NSString stringWithCString:(char *)serviceStr encoding:NSUTF8StringEncoding],
+			(__bridge id)kSecAttrAccount: [NSString stringWithCString:(char *)keyStr encoding:NSUTF8StringEncoding],
+			(__bridge id)kSecValueData: [NSData dataWithBytes:pwStr length:length]
+		};
 
-        } else {
-            NSLog(@"Error storing item in keychain. Status code: %d", (int)status);
-        }
+		status = SecItemAdd((__bridge CFDictionaryRef)keychainAttributes, NULL);
 
-    (*env)->ReleaseByteArrayElements(env, service, serviceStr, JNI_ABORT);
-    (*env)->ReleaseByteArrayElements(env, key, keyStr, JNI_ABORT);
-    (*env)->ReleaseByteArrayElements(env, password, pwStr, JNI_ABORT);
+	} else {
+		NSLog(@"Error storing item in keychain. Status code: %d", (int)status);
+	}
 
-    return status;
+	(*env)->ReleaseByteArrayElements(env, service, serviceStr, JNI_ABORT);
+	(*env)->ReleaseByteArrayElements(env, key, keyStr, JNI_ABORT);
+	(*env)->ReleaseByteArrayElements(env, password, pwStr, JNI_ABORT);
+
+	return status;
 }
 
 JNIEXPORT jbyteArray JNICALL Java_org_cryptomator_macos_keychain_MacKeychain_00024Native_loadPassword(JNIEnv *env, jobject thisObj, jbyteArray service, jbyteArray key) {
 	jbyte *serviceStr = (*env)->GetByteArrayElements(env, service, NULL);
 	jbyte *keyStr = (*env)->GetByteArrayElements(env, key, NULL);
 
-    // Create a dictionary of search attributes to find the item in the keychain
-    NSDictionary *searchAttributes = @{
-        (__bridge id)kSecClass: (__bridge id)kSecClassGenericPassword,
-        (__bridge id)kSecAttrService: [NSString stringWithCString:(char *)serviceStr encoding:NSUTF8StringEncoding],
-        (__bridge id)kSecAttrAccount: [NSString stringWithCString:(char *)keyStr encoding:NSUTF8StringEncoding],
-        (__bridge id)kSecReturnAttributes: @YES,
-        (__bridge id)kSecReturnData: @YES,
-        (__bridge id)kSecMatchLimit: (__bridge id)kSecMatchLimitOne
-    };
-        
-    CFDictionaryRef result = NULL;
-    OSStatus status = SecItemCopyMatching((__bridge CFDictionaryRef)searchAttributes, (CFTypeRef *)&result);
+	// Create a dictionary of search attributes to find the item in the keychain
+	NSDictionary *searchAttributes = @{
+		(__bridge id)kSecClass: (__bridge id)kSecClassGenericPassword,
+		(__bridge id)kSecAttrService: [NSString stringWithCString:(char *)serviceStr encoding:NSUTF8StringEncoding],
+		(__bridge id)kSecAttrAccount: [NSString stringWithCString:(char *)keyStr encoding:NSUTF8StringEncoding],
+		(__bridge id)kSecReturnAttributes: @YES,
+		(__bridge id)kSecReturnData: @YES,
+		(__bridge id)kSecMatchLimit: (__bridge id)kSecMatchLimitOne
+	};
+						
+	CFDictionaryRef result = NULL;
+	OSStatus status = SecItemCopyMatching((__bridge CFDictionaryRef)searchAttributes, (CFTypeRef *)&result);
 
-    (*env)->ReleaseByteArrayElements(env, service, serviceStr, JNI_ABORT);
-    (*env)->ReleaseByteArrayElements(env, key, keyStr, JNI_ABORT);
+	(*env)->ReleaseByteArrayElements(env, service, serviceStr, JNI_ABORT);
+	(*env)->ReleaseByteArrayElements(env, key, keyStr, JNI_ABORT);
 
-    if (status == errSecSuccess && result != NULL) {
-            NSDictionary *attributes = (__bridge_transfer NSDictionary *)result;
-            NSData *passwordData = attributes[(__bridge id)kSecValueData];
+	if (status == errSecSuccess && result != NULL) {
+		NSDictionary *attributes = (__bridge_transfer NSDictionary *)result;
+		NSData *passwordData = attributes[(__bridge id)kSecValueData];
 
-            NSUInteger pwLen = [passwordData length];
-            const void *pwBytes = [passwordData bytes];
+		NSUInteger pwLen = [passwordData length];
+		const void *pwBytes = [passwordData bytes];
 
-            jbyteArray password = (*env)->NewByteArray(env, (int)pwLen);
-            (*env)->SetByteArrayRegion(env, password, 0, (int)pwLen, (jbyte *)pwBytes);
+		jbyteArray password = (*env)->NewByteArray(env, (int)pwLen);
+		(*env)->SetByteArrayRegion(env, password, 0, (int)pwLen, (jbyte *)pwBytes);
 
-            return password;
+		return password;
 
-        } else if (status != errSecItemNotFound) {
-            NSLog(@"Error retrieving item from keychain. Status code: %d", (int)status);
-        }
+	} else if (status != errSecItemNotFound) {
+		NSLog(@"Error retrieving item from keychain. Status code: %d", (int)status);
+	}
 
-    return NULL; // empty
+	return NULL; // empty
 }
 
 JNIEXPORT jint JNICALL Java_org_cryptomator_macos_keychain_MacKeychain_00024Native_deletePassword(JNIEnv *env, jobject thisObj, jbyteArray service, jbyteArray key) {
-    jbyte *serviceStr = (*env)->GetByteArrayElements(env, service, NULL);
-    jbyte *keyStr = (*env)->GetByteArrayElements(env, key, NULL);
+	jbyte *serviceStr = (*env)->GetByteArrayElements(env, service, NULL);
+	jbyte *keyStr = (*env)->GetByteArrayElements(env, key, NULL);
 
-    // find existing:
-    NSDictionary *searchAttributes = @{
-        (__bridge id)kSecClass: (__bridge id)kSecClassGenericPassword,
-        (__bridge id)kSecAttrService: [NSString stringWithCString:(char *)serviceStr encoding:NSUTF8StringEncoding],
-        (__bridge id)kSecAttrAccount: [NSString stringWithCString:(char *)keyStr encoding:NSUTF8StringEncoding],
-        (__bridge id)kSecMatchLimit: (__bridge id)kSecMatchLimitOne
-    };
-        
-    CFDictionaryRef result = NULL;
-    OSStatus status = SecItemCopyMatching((__bridge CFDictionaryRef)searchAttributes, (CFTypeRef *)&result);
+	// find existing:
+	NSDictionary *searchAttributes = @{
+		(__bridge id)kSecClass: (__bridge id)kSecClassGenericPassword,
+		(__bridge id)kSecAttrService: [NSString stringWithCString:(char *)serviceStr encoding:NSUTF8StringEncoding],
+		(__bridge id)kSecAttrAccount: [NSString stringWithCString:(char *)keyStr encoding:NSUTF8StringEncoding],
+		(__bridge id)kSecMatchLimit: (__bridge id)kSecMatchLimitOne
+	};
+								
+	CFDictionaryRef result = NULL;
+	OSStatus status = SecItemCopyMatching((__bridge CFDictionaryRef)searchAttributes, (CFTypeRef *)&result);
 
-    if (status == errSecSuccess && result != NULL) {
+	if (status == errSecSuccess && result != NULL) {
 
-        status = SecItemDelete((__bridge CFDictionaryRef)searchAttributes);
+		status = SecItemDelete((__bridge CFDictionaryRef)searchAttributes);
 
-        } else if (status != errSecItemNotFound) {
-            NSLog(@"Error deleting item from keychain. Status code: %d", (int)status);
-        }
+	} else if (status != errSecItemNotFound) {
+		NSLog(@"Error deleting item from keychain. Status code: %d", (int)status);
+	}
 
-    (*env)->ReleaseByteArrayElements(env, service, serviceStr, JNI_ABORT);
-    (*env)->ReleaseByteArrayElements(env, key, keyStr, JNI_ABORT);
+	(*env)->ReleaseByteArrayElements(env, service, serviceStr, JNI_ABORT);
+	(*env)->ReleaseByteArrayElements(env, key, keyStr, JNI_ABORT);
 
-    return status;
+	return status;
 }

--- a/src/main/native/org_cryptomator_macos_keychain_MacKeychain_Native.m
+++ b/src/main/native/org_cryptomator_macos_keychain_MacKeychain_Native.m
@@ -7,117 +7,145 @@
 //
 
 #import "org_cryptomator_macos_keychain_MacKeychain_Native.h"
+#import <Foundation/Foundation.h>
 #import <Security/Security.h>
 
+// the kServiceName must be the same as in the project settings > Keychain Sharing > Keychain Groups
+
+SecAccessControlRef createAccessControl(void) {
+    SecAccessControlCreateFlags flags = kSecAccessControlUserPresence;
+    
+    SecAccessControlRef accessControl = SecAccessControlCreateWithFlags(
+        kCFAllocatorDefault,
+        kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly,
+        flags,
+        NULL // Ignore any error
+    );
+    
+    return accessControl;
+}
+
 JNIEXPORT jint JNICALL Java_org_cryptomator_macos_keychain_MacKeychain_00024Native_storePassword(JNIEnv *env, jobject thisObj, jbyteArray service, jbyteArray key, jbyteArray password) {
-	const int serviceLen = (*env)->GetArrayLength(env, service);
 	jbyte *serviceStr = (*env)->GetByteArrayElements(env, service, NULL);
-	const int keyLen = (*env)->GetArrayLength(env, key);
 	jbyte *keyStr = (*env)->GetByteArrayElements(env, key, NULL);
-	const int pwLen = (*env)->GetArrayLength(env, password);
 	jbyte *pwStr = (*env)->GetByteArrayElements(env, password, NULL);
 
 	// find existing:
-	SecKeychainItemRef itemRef = NULL;
-	OSStatus status = SecKeychainFindGenericPassword(
-	    NULL,                // default keychain
-	    serviceLen,          // length of service name
-	    (char *)serviceStr,  // service name
-	    keyLen,              // length of account name
-	    (char *)keyStr,      // account name
-	    NULL,                // length of password
-	    NULL,                // pointer to password data
-	    &itemRef             // the item reference
-	    );
-	if (status == errSecSuccess) {
-		// update existing:
-		status = SecKeychainItemModifyAttributesAndData(
-		    itemRef, // the item reference
-		    NULL,    // no change to attributes
-		    pwLen,   // length of password
-		    pwStr    // pointer to password data
-		    );
-	} else if (status == errSecItemNotFound) {
-		// add new:
-		status = SecKeychainAddGenericPassword(
-		    NULL,                // default keychain
-		    serviceLen,          // length of service name
-		    (char *)serviceStr,  // service name
-		    keyLen,              // length of account name
-		    (char *)keyStr,      // account name
-		    pwLen,               // length of password
-		    pwStr,               // pointer to password data
-		    NULL                 // the item reference
-		    );
-	}
+    NSDictionary *searchAttributes = @{
+        (__bridge id)kSecClass: (__bridge id)kSecClassGenericPassword,
+        (__bridge id)kSecAttrService: [NSString stringWithCString:(char *)serviceStr encoding:NSUTF8StringEncoding],
+        (__bridge id)kSecAttrAccount: [NSString stringWithCString:(char *)keyStr encoding:NSUTF8StringEncoding],
+        (__bridge id)kSecReturnAttributes: @YES,
+        (__bridge id)kSecReturnData: @YES,
+        (__bridge id)kSecMatchLimit: (__bridge id)kSecMatchLimitOne
+    };
+        
+    CFDictionaryRef result = NULL;
+    OSStatus status = SecItemCopyMatching((__bridge CFDictionaryRef)searchAttributes, (CFTypeRef *)&result);
 
-	(*env)->ReleaseByteArrayElements(env, key, keyStr, JNI_ABORT);
-	(*env)->ReleaseByteArrayElements(env, password, pwStr, JNI_ABORT);
-	if (itemRef) {
-		CFRelease(itemRef);
-	}
-	return status;
+    if (status == errSecSuccess && result != NULL) {
+        NSLog(@"Item found in keychain, updating it.");
+
+        // update existing:
+        NSDictionary *changeAttributes = @{
+            (__bridge id)kSecValueData:  [NSString stringWithCString:(char *)pwStr encoding:NSUTF8StringEncoding]
+        };
+
+        status = SecItemUpdate((__bridge CFDictionaryRef)searchAttributes, (__bridge CFDictionaryRef)changeAttributes);
+
+        } else if (status == errSecItemNotFound) {
+            NSLog(@"Adding item to keychain.");
+
+            // add new:
+            NSDictionary *keychainAttributes = @{
+                (__bridge id)kSecClass: (__bridge id)kSecClassGenericPassword,
+                (__bridge id)kSecAttrService: [NSString stringWithCString:(char *)serviceStr encoding:NSUTF8StringEncoding],
+                (__bridge id)kSecAttrAccessControl: (__bridge_transfer id)createAccessControl(),
+                (__bridge id)kSecAttrAccount: [NSString stringWithCString:(char *)keyStr encoding:NSUTF8StringEncoding],
+                (__bridge id)kSecValueData:  [NSString stringWithCString:(char *)pwStr encoding:NSUTF8StringEncoding]
+            };
+
+            status = SecItemAdd((__bridge CFDictionaryRef)keychainAttributes, NULL);
+
+        } else {
+            NSLog(@"Error storing item in keychain. Status code: %d", (int)status);
+        }
+
+    (*env)->ReleaseByteArrayElements(env, key, keyStr, JNI_ABORT);
+    (*env)->ReleaseByteArrayElements(env, password, pwStr, JNI_ABORT);
+
+    return status;
 }
 
 JNIEXPORT jbyteArray JNICALL Java_org_cryptomator_macos_keychain_MacKeychain_00024Native_loadPassword(JNIEnv *env, jobject thisObj, jbyteArray service, jbyteArray key) {
-	const int serviceLen = (*env)->GetArrayLength(env, service);
 	jbyte *serviceStr = (*env)->GetByteArrayElements(env, service, NULL);
-	const int keyLen = (*env)->GetArrayLength(env, key);
 	jbyte *keyStr = (*env)->GetByteArrayElements(env, key, NULL);
-	void *pwStr = NULL;
-	UInt32 pwLen;
-	OSStatus status = SecKeychainFindGenericPassword(
-	    NULL,                // default keychain
-	    serviceLen,          // length of service name
-	    (char *)serviceStr,  // service name
-	    keyLen,              // length of account name
-	    (char *)keyStr,      // account name
-	    &pwLen,              // length of password
-	    &pwStr,              // pointer to password data
-	    NULL                 // the item reference
-	    );
 
-	jbyteArray result;
-	if (status == errSecSuccess) {
-		result = (*env)->NewByteArray(env, pwLen);
-		(*env)->SetByteArrayRegion(env, result, 0, pwLen, pwStr);
-	} else {
-		result = NULL;
-	}
+    // Create a dictionary of search attributes to find the item in the keychain
+        NSDictionary *searchAttributes = @{
+            (__bridge id)kSecClass: (__bridge id)kSecClassGenericPassword,
+            (__bridge id)kSecAttrService: [NSString stringWithCString:(char *)serviceStr encoding:NSUTF8StringEncoding],
+            (__bridge id)kSecAttrAccount: [NSString stringWithCString:(char *)keyStr encoding:NSUTF8StringEncoding],
+            (__bridge id)kSecReturnAttributes: @YES,
+            (__bridge id)kSecReturnData: @YES,
+            (__bridge id)kSecMatchLimit: (__bridge id)kSecMatchLimitOne
+        };
+        
+        CFDictionaryRef result = NULL;
+        OSStatus status = SecItemCopyMatching((__bridge CFDictionaryRef)searchAttributes, (CFTypeRef *)&result);
 
-	(*env)->ReleaseByteArrayElements(env, key, keyStr, JNI_ABORT);
-	if (pwStr) {
-		SecKeychainItemFreeContent(NULL, pwStr);
-	}
-	return result;
+    (*env)->ReleaseByteArrayElements(env, key, keyStr, JNI_ABORT);
+
+    if (status == errSecSuccess && result != NULL) {
+            NSDictionary *attributes = (__bridge_transfer NSDictionary *)result;
+            NSData *passwordData = attributes[(__bridge id)kSecValueData];
+            NSLog(@"Item found in keychain.");
+
+            NSUInteger pwLen = [passwordData length];
+            const void *pwBytes = [passwordData bytes];
+
+            jbyteArray password = (*env)->NewByteArray(env, (int)pwLen);
+            (*env)->SetByteArrayRegion(env, password, 0, (int)pwLen, (jbyte *)pwBytes);
+
+            return password;
+
+        } else if (status == errSecItemNotFound) {
+            NSLog(@"No matching item found in the keychain.");
+        } else {
+            NSLog(@"Error retrieving item from keychain. Status code: %d", (int)status);
+        }
+
+    return NULL; // empty
 }
 
 JNIEXPORT jint JNICALL Java_org_cryptomator_macos_keychain_MacKeychain_00024Native_deletePassword(JNIEnv *env, jobject thisObj, jbyteArray service, jbyteArray key) {
-	const int serviceLen = (*env)->GetArrayLength(env, service);
-	jbyte *serviceStr = (*env)->GetByteArrayElements(env, service, NULL);
-	const int keyLen = (*env)->GetArrayLength(env, key);
-	jbyte *keyStr = (*env)->GetByteArrayElements(env, key, NULL);
-	SecKeychainItemRef itemRef = NULL;
-	OSStatus status = SecKeychainFindGenericPassword(
-	    NULL,                // default keychain
-	    serviceLen,          // length of service name
-	    (char *)serviceStr,  // service name
-	    keyLen,              // length of account name
-	    (char *)keyStr,      // account name
-	    NULL,                // length of password
-	    NULL,                // pointer to password data
-	    &itemRef             // the item reference
-	    );
+    jbyte *serviceStr = (*env)->GetByteArrayElements(env, service, NULL);
+    jbyte *keyStr = (*env)->GetByteArrayElements(env, key, NULL);
 
-	if (status == errSecSuccess) {
-		status = SecKeychainItemDelete(
-		    itemRef // the item reference
-		    );
-	}
+    // find existing:
+    NSDictionary *searchAttributes = @{
+        (__bridge id)kSecClass: (__bridge id)kSecClassGenericPassword,
+        (__bridge id)kSecAttrService: [NSString stringWithCString:(char *)serviceStr encoding:NSUTF8StringEncoding],
+        (__bridge id)kSecAttrAccount: [NSString stringWithCString:(char *)keyStr encoding:NSUTF8StringEncoding],
+        (__bridge id)kSecMatchLimit: (__bridge id)kSecMatchLimitOne
+    };
+        
+    CFDictionaryRef result = NULL;
+    OSStatus status = SecItemCopyMatching((__bridge CFDictionaryRef)searchAttributes, (CFTypeRef *)&result);
 
-	(*env)->ReleaseByteArrayElements(env, key, keyStr, JNI_ABORT);
-	if (itemRef) {
-		CFRelease(itemRef);
-	}
-	return status;
+    if (status == errSecSuccess && result != NULL) {
+        NSLog(@"Item found in keychain, deleting it.");
+
+        status = SecItemDelete((__bridge CFDictionaryRef)searchAttributes);
+
+        } else if (status == errSecItemNotFound) {
+            NSLog(@"No matching item found in the keychain.");
+
+        } else {
+            NSLog(@"Error deleting item from keychain. Status code: %d", (int)status);
+        }
+
+    (*env)->ReleaseByteArrayElements(env, key, keyStr, JNI_ABORT);
+
+    return status;
 }

--- a/src/main/native/org_cryptomator_macos_keychain_MacKeychain_Native.m
+++ b/src/main/native/org_cryptomator_macos_keychain_MacKeychain_Native.m
@@ -17,7 +17,7 @@ static SecAccessControlRef createAccessControl(void) {
     
     SecAccessControlRef accessControl = SecAccessControlCreateWithFlags(
         kCFAllocatorDefault,
-        kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly,
+        kSecAttrAccessibleWhenUnlocked,
         flags,
         NULL // Ignore any error
     );


### PR DESCRIPTION
As the title says, this introduces `SecItem`, without breaking anything. So this PR is ready for review.

Also, `SecItem` is the base for having keychain access control and Touch ID support (which is not part of this PR, see https://github.com/cryptomator/cryptomator/pull/3311#issuecomment-2133822479).