### PR TITLE
Add Touch ID provider

### DIFF
--- a/src/main/headers/org_cryptomator_macos_keychain_MacKeychain_Native.h
+++ b/src/main/headers/org_cryptomator_macos_keychain_MacKeychain_Native.h
@@ -31,6 +31,14 @@ JNIEXPORT jbyteArray JNICALL Java_org_cryptomator_macos_keychain_MacKeychain_000
 JNIEXPORT jint JNICALL Java_org_cryptomator_macos_keychain_MacKeychain_00024Native_deletePassword
   (JNIEnv *, jobject, jbyteArray, jbyteArray);
 
+/*
+ * Class:     org_cryptomator_macos_keychain_MacKeychain_Native
+ * Method:    isTouchIDavailable
+ * Signature: ()Z
+ */
+JNIEXPORT jboolean JNICALL Java_org_cryptomator_macos_keychain_MacKeychain_00024Native_isTouchIDavailable
+  (JNIEnv *, jobject);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -5,6 +5,7 @@ import org.cryptomator.integrations.tray.TrayIntegrationProvider;
 import org.cryptomator.integrations.uiappearance.UiAppearanceProvider;
 import org.cryptomator.macos.autostart.MacAutoStartProvider;
 import org.cryptomator.macos.keychain.MacSystemKeychainAccess;
+import org.cryptomator.macos.keychain.TouchIdKeychainAccess;
 import org.cryptomator.macos.revealpath.OpenCmdRevealPathService;
 import org.cryptomator.macos.tray.MacTrayIntegrationProvider;
 import org.cryptomator.macos.uiappearance.MacUiAppearanceProvider;
@@ -14,7 +15,7 @@ module org.cryptomator.integrations.mac {
 	requires org.slf4j;
 
 	provides AutoStartProvider with MacAutoStartProvider;
-	provides KeychainAccessProvider with MacSystemKeychainAccess;
+	provides KeychainAccessProvider with MacSystemKeychainAccess, TouchIdKeychainAccess;
 	provides RevealPathService with OpenCmdRevealPathService;
 	provides TrayIntegrationProvider with MacTrayIntegrationProvider;
 	provides UiAppearanceProvider with MacUiAppearanceProvider;

--- a/src/main/java/org/cryptomator/macos/keychain/MacKeychain.java
+++ b/src/main/java/org/cryptomator/macos/keychain/MacKeychain.java
@@ -104,6 +104,15 @@ class MacKeychain {
 		}
 	}
 
+	/**
+	 * Tests whether biometric authentication via Touch ID is supported and allowed on the device
+	 *
+	 * @return <code>true</code> if biometric authentication is available, <code>false</code> otherwise
+	 */
+	public boolean isTouchIDavailable() {
+		return Native.INSTANCE.isTouchIDavailable();
+	}
+
 	// initialization-on-demand pattern, as loading the .dylib is an expensive operation
 	private static class Native {
 		static final Native INSTANCE = new Native();
@@ -117,6 +126,8 @@ class MacKeychain {
 		public native byte[] loadPassword(byte[] service, byte[] account);
 
 		public native int deletePassword(byte[] service, byte[] account);
+
+		public native boolean isTouchIDavailable();
 	}
 
 }

--- a/src/main/java/org/cryptomator/macos/keychain/TouchIdKeychainAccess.java
+++ b/src/main/java/org/cryptomator/macos/keychain/TouchIdKeychainAccess.java
@@ -13,7 +13,7 @@ import org.cryptomator.macos.common.Localization;
  * Items are stored in the default keychain with the service name <code>Cryptomator</code>, unless configured otherwise
  * using the system property <code>cryptomator.integrationsMac.keychainServiceName</code>.
  */
-@Priority(1000)
+@Priority(1010)
 @OperatingSystem(OperatingSystem.Value.MAC)
 public class TouchIdKeychainAccess implements KeychainAccessProvider {
 

--- a/src/main/java/org/cryptomator/macos/keychain/TouchIdKeychainAccess.java
+++ b/src/main/java/org/cryptomator/macos/keychain/TouchIdKeychainAccess.java
@@ -7,36 +7,37 @@ import org.cryptomator.integrations.keychain.KeychainAccessProvider;
 import org.cryptomator.macos.common.Localization;
 
 /**
- * Stores passwords in the macOS system keychain.
+ * Stores passwords in the macOS system keychain. Requires an authenticated user to do so.
+ * Authentication is done via TouchID or password as a fallback, when TouchID is not available.
  * <p>
  * Items are stored in the default keychain with the service name <code>Cryptomator</code>, unless configured otherwise
  * using the system property <code>cryptomator.integrationsMac.keychainServiceName</code>.
  */
 @Priority(1000)
 @OperatingSystem(OperatingSystem.Value.MAC)
-public class MacSystemKeychainAccess implements KeychainAccessProvider {
+public class TouchIdKeychainAccess implements KeychainAccessProvider {
 
 	private static final String SERVICE_NAME = System.getProperty("cryptomator.integrationsMac.keychainServiceName", "Cryptomator");
 
 	private final MacKeychain keychain;
 
-	public MacSystemKeychainAccess() {
+	public TouchIdKeychainAccess() {
 		this(new MacKeychain());
 	}
 
 	// visible for testing
-	MacSystemKeychainAccess(MacKeychain keychain) {
+	TouchIdKeychainAccess(MacKeychain keychain) {
 		this.keychain = keychain;
 	}
 
 	@Override
 	public String displayName() {
-		return Localization.get().getString("org.cryptomator.macos.keychain.displayName");
+		return Localization.get().getString("org.cryptomator.macos.keychain.touchIdDisplayName");
 	}
 
 	@Override
 	public void storePassphrase(String key, String displayName, CharSequence passphrase) throws KeychainAccessException {
-		keychain.storePassword(SERVICE_NAME, key, passphrase, false);
+		keychain.storePassword(SERVICE_NAME, key, passphrase, true);
 	}
 
 	@Override
@@ -67,7 +68,7 @@ public class MacSystemKeychainAccess implements KeychainAccessProvider {
 	@Override
 	public void changePassphrase(String key, String displayName, CharSequence passphrase) throws KeychainAccessException {
 		if (keychain.deletePassword(SERVICE_NAME, key)) {
-			keychain.storePassword(SERVICE_NAME, key, passphrase, false);
+			keychain.storePassword(SERVICE_NAME, key, passphrase, true);
 		}
 	}
 

--- a/src/main/java/org/cryptomator/macos/keychain/TouchIdKeychainAccess.java
+++ b/src/main/java/org/cryptomator/macos/keychain/TouchIdKeychainAccess.java
@@ -52,7 +52,7 @@ public class TouchIdKeychainAccess implements KeychainAccessProvider {
 
 	@Override
 	public boolean isSupported() {
-		return true;
+		return keychain.isTouchIDavailable();
 	}
 
 	@Override

--- a/src/main/native/org_cryptomator_macos_keychain_MacKeychain_Native.m
+++ b/src/main/native/org_cryptomator_macos_keychain_MacKeychain_Native.m
@@ -123,3 +123,14 @@ JNIEXPORT jint JNICALL Java_org_cryptomator_macos_keychain_MacKeychain_00024Nati
 	(*env)->ReleaseByteArrayElements(env, key, keyStr, JNI_ABORT);
 	return status;
 }
+
+JNIEXPORT jboolean JNICALL Java_org_cryptomator_macos_keychain_MacKeychain_00024Native_isTouchIDavailable(JNIEnv *env, jobject thisObj) {
+	NSError *error = nil;
+	LAContext *context = getSharedLAContext();
+	if ([context canEvaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics error:&error]) {
+		return JNI_TRUE;
+	} else {
+		NSLog(@"Touch ID is not available: %@", error.localizedDescription);
+		return JNI_FALSE;
+	}
+}

--- a/src/main/resources/META-INF/services/org.cryptomator.integrations.keychain.KeychainAccessProvider
+++ b/src/main/resources/META-INF/services/org.cryptomator.integrations.keychain.KeychainAccessProvider
@@ -1,1 +1,2 @@
 org.cryptomator.macos.keychain.MacSystemKeychainAccess
+org.cryptomator.macos.keychain.TouchIdKeychainAccess

--- a/src/main/resources/META-INF/services/org.cryptomator.integrations.keychain.TouchIdKeychainAccessProvider
+++ b/src/main/resources/META-INF/services/org.cryptomator.integrations.keychain.TouchIdKeychainAccessProvider
@@ -1,0 +1,1 @@
+org.cryptomator.macos.keychain.TouchIdKeychainAccess

--- a/src/main/resources/META-INF/services/org.cryptomator.integrations.keychain.TouchIdKeychainAccessProvider
+++ b/src/main/resources/META-INF/services/org.cryptomator.integrations.keychain.TouchIdKeychainAccessProvider
@@ -1,1 +1,0 @@
-org.cryptomator.macos.keychain.TouchIdKeychainAccess

--- a/src/main/resources/MacIntegrationsBundle.properties
+++ b/src/main/resources/MacIntegrationsBundle.properties
@@ -1,1 +1,2 @@
 org.cryptomator.macos.keychain.displayName=macOS Keychain
+org.cryptomator.macos.keychain.touchIdDisplayName=Touch ID

--- a/src/test/java/org/cryptomator/macos/keychain/KeychainAccessProviderTest.java
+++ b/src/test/java/org/cryptomator/macos/keychain/KeychainAccessProviderTest.java
@@ -12,7 +12,9 @@ public class KeychainAccessProviderTest {
 	public void testLoadMacSystemKeychainAccess() {
 		var provider = KeychainAccessProvider.get().findAny();
 		Assertions.assertTrue(provider.isPresent());
-		Assertions.assertInstanceOf(TouchIdKeychainAccess.class, provider.get());
+		Assertions.assertTrue(
+				provider.get() instanceof TouchIdKeychainAccess
+						|| provider.get() instanceof MacSystemKeychainAccess);
 	}
 
 }

--- a/src/test/java/org/cryptomator/macos/keychain/KeychainAccessProviderTest.java
+++ b/src/test/java/org/cryptomator/macos/keychain/KeychainAccessProviderTest.java
@@ -12,7 +12,7 @@ public class KeychainAccessProviderTest {
 	public void testLoadMacSystemKeychainAccess() {
 		var provider = KeychainAccessProvider.get().findAny();
 		Assertions.assertTrue(provider.isPresent());
-		Assertions.assertInstanceOf(MacSystemKeychainAccess.class, provider.get());
+		Assertions.assertInstanceOf(TouchIdKeychainAccess.class, provider.get());
 	}
 
 }


### PR DESCRIPTION
Following the [recommendation](https://github.com/cryptomator/integrations-win/pull/83#issuecomment-2506424388) in the PR for Windows Hello, Touch ID gets its own provider.